### PR TITLE
[IWJ-10] Add transfer form validation

### DIFF
--- a/src/renderer/components/TransferForm.vue
+++ b/src/renderer/components/TransferForm.vue
@@ -1,26 +1,28 @@
 <template>
   <el-form
     class="transfer-form"
+    ref="form"
     :model="form"
+    :rules="rules"
     label-width="6rem"
   >
-    <el-form-item label="TO:">
-      <el-input v-model="form.to" />
+    <el-form-item label="TO:" prop="to">
+      <el-input name="to" v-model="form.to" />
     </el-form-item>
 
-    <el-form-item label="AMOUNT:">
-      <el-input v-model="form.amount" type="number" />
+    <el-form-item label="AMOUNT:" prop="amount">
+      <el-input name="amount" v-model="form.amount" />
     </el-form-item>
 
-    <el-form-item label="MESSAGE:">
-      <el-input v-model="form.message" type="textarea" />
+    <el-form-item label="MESSAGE:" prop="message">
+      <el-input name="message" v-model="form.message" type="textarea" />
     </el-form-item>
 
     <el-form-item class="send-button-container">
       <el-button
         class="send-button"
         type="primary"
-        @click="$emit('submit')"
+        @click="onSubmit"
       >
         SEND
       </el-button>
@@ -37,11 +39,52 @@
       event: 'change'
     },
 
-    props: ['form'],
+    props: {
+      form: Object,
+      maxDecimalDigits: {
+        validator: v => Number.isInteger(v) && v >= 1
+      }
+    },
+
+    data () {
+      // `maxDecimalDigits` specifies the maximum number of digits after decimal point.
+      // e.g. if maxDecimalDigits == 5 then '100.12345' is ok
+      const amountRegexp = RegExp(`^[1-9][0-9]{0,32}(\\.[0-9]{1,${this.maxDecimalDigits}})?$`)
+      const amountMessage = `"AMOUNT" should be a number of max ${this.maxDecimalDigits} decimal digits.`
+
+      return {
+        rules: {
+          to: [
+            { required: true, message: 'Please input "TO"', trigger: 'change' },
+            { pattern: /^[a-z_0-9]{1,32}@[a-z_0-9]{1,9}$/, message: '"TO" should match [a-Z_0-9]{1,32}@[a-Z_0-9]{1,9}', trigger: 'change' }
+          ],
+          amount: [
+            { required: true, message: 'Please input "AMOUNT"', trigger: 'change' },
+            { pattern: amountRegexp, message: amountMessage, trigger: 'change' }
+          ]
+        }
+      }
+    },
 
     watch: {
       form (to) {
         this.$emit('change', to)
+      }
+    },
+
+    methods: {
+      onSubmit () {
+        this.$refs['form'].validate(valid => {
+          if (valid) {
+            this.$emit('submit')
+          } else {
+            return false
+          }
+        })
+      },
+
+      clearValidationMessage () {
+        this.$refs['form'].clearValidate()
       }
     }
   }

--- a/src/renderer/components/TransferForm.vue
+++ b/src/renderer/components/TransferForm.vue
@@ -42,18 +42,22 @@
     props: {
       form: Object,
       maxDecimalDigits: {
-        validator: v => Number.isInteger(v) && v >= 1
+        validator: v => Number.isInteger(v) && v >= 0
       }
     },
 
-    data () {
-      // `maxDecimalDigits` specifies the maximum number of digits after decimal point.
-      // e.g. if maxDecimalDigits == 5 then '100.12345' is ok
-      const amountRegexp = RegExp(`^[1-9][0-9]{0,32}(\\.[0-9]{1,${this.maxDecimalDigits}})?$`)
-      const amountMessage = `"AMOUNT" should be a number of max ${this.maxDecimalDigits} decimal digits.`
+    computed: {
+      rules () {
+        // `maxDecimalDigits` specifies the maximum number of digits after decimal point.
+        // e.g. if maxDecimalDigits == 5 then '100.12345' is ok
+        const amountRegexp = (this.maxDecimalDigits !== 0)
+          ? RegExp(`^[1-9][0-9]*(\\.[0-9]{1,${this.maxDecimalDigits}})?$`)
+          : RegExp(`^[1-9][0-9]*$`)
+        const amountMessage = (this.maxDecimalDigits !== 0)
+          ? `"AMOUNT" should be a number of max ${this.maxDecimalDigits} decimal digits.`
+          : `"AMOUNT" should be an integer.`
 
-      return {
-        rules: {
+        return {
           to: [
             { required: true, message: 'Please input "TO"', trigger: 'change' },
             { pattern: /^[a-z_0-9]{1,32}@[a-z_0-9]{1,9}$/, message: '"TO" should match [a-Z_0-9]{1,32}@[a-Z_0-9]{1,9}', trigger: 'change' }

--- a/src/renderer/components/TransferForm.vue
+++ b/src/renderer/components/TransferForm.vue
@@ -95,8 +95,6 @@
 </script>
 
 <style lang="scss" scoped>
-  @import "~@/styles/element-variables.scss";
-
   .transfer-form {
     margin: 2rem 4rem 0 0;
 

--- a/src/renderer/components/Wallet.vue
+++ b/src/renderer/components/Wallet.vue
@@ -11,7 +11,7 @@
         <transfer-form
           ref="form"
           v-model="form"
-          :maxDecimalDigits="5"
+          :maxDecimalDigits="maxDecimalDigits"
           @submit="onSubmit"
         ></transfer-form>
       </el-tab-pane>
@@ -37,7 +37,8 @@
         activeTabName: 'history',
         wallet: {},
         transactions: [],
-        form: {}
+        form: {},
+        maxDecimalDigits: 0
       }
     },
 
@@ -50,15 +51,17 @@
         // Reset the instance's data c.f. https://github.com/vuejs/vue/issues/702
         Object.assign(this.$data, this.$options.data())
 
-        this.$refs['form'].clearValidationMessage()
         this.fetchWalletByWalletId(this.$route.params.walletId)
         this.fetchTransactionsByWalletId(this.$route.params.walletId)
+        this.updateMaxDecimalDegits()
+        this.$nextTick(() => this.$refs['form'].clearValidationMessage())
       }
     },
 
     created () {
       this.fetchWalletByWalletId(this.$route.params.walletId)
       this.fetchTransactionsByWalletId(this.$route.params.walletId)
+      this.updateMaxDecimalDegits()
     },
 
     methods: {
@@ -105,6 +108,13 @@
           .chain()
           .sampleSize(_.random(3, 20))
           .value()
+      },
+
+      /**
+       * TODO: This is dummy. maxDecimalDigits is different for every asset
+       */
+      updateMaxDecimalDegits () {
+        this.maxDecimalDigits = _.random(0, 5)
       },
 
       onSubmit () {

--- a/src/renderer/components/Wallet.vue
+++ b/src/renderer/components/Wallet.vue
@@ -8,7 +8,12 @@
       </el-tab-pane>
 
       <el-tab-pane label="SEND" name="send">
-        <transfer-form v-model="form" @submit="onSubmit"></transfer-form>
+        <transfer-form
+          ref="form"
+          v-model="form"
+          :maxDecimalDigits="5"
+          @submit="onSubmit"
+        ></transfer-form>
       </el-tab-pane>
     </el-tabs>
   </div>
@@ -45,6 +50,7 @@
         // Reset the instance's data c.f. https://github.com/vuejs/vue/issues/702
         Object.assign(this.$data, this.$options.data())
 
+        this.$refs['form'].clearValidationMessage()
         this.fetchWalletByWalletId(this.$route.params.walletId)
         this.fetchTransactionsByWalletId(this.$route.params.walletId)
       }


### PR DESCRIPTION
ℹ️ To compare diffs with the base branch #5 which isn't merged yet, the target branch is set as:
* (temporary) feature/IWJ-9-create-wallets-transfer
* (correct) develop (set to this after #5 is merged)

# Ticket
https://soramitsu.atlassian.net/browse/IWJ-10

# Description
Add validation to transfer form:
* TO
  * `^[a-z_0-9]{1,32}@[a-z_0-9]{1,9}$`
  * as the same as [a login page](https://soramitsu.atlassian.net/browse/IWJ-4)
* AMOUNT
  * a number of max `maxDecimalDigits` digits.
  * `maxDecimalDigits` is different for each wallet. (0~5 random value for now)
  * note that an input is treated as String internally to avoid rounding
* MESSAGE
  * no validation

# How to check
1. `yarn dev` to open the app.
2. Go to a transfer form and check validation.

