### PR TITLE
No sleep

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,18 +12,32 @@ export default {
   name: 'iroha-wallet-js',
 
   computed: mapState({
-    connectionError: state => state.Account.connectionError
+    connectionError: state => state.Account.connectionError,
+    transferError: state => state.Account.transferError
   }),
 
   watch: {
     connectionError (to) {
       if (to) this.showConnectionErrorMessage(to)
+    },
+    transferError (to) {
+      if (to) this.showTransferErrorMessage(to)
     }
   },
 
   methods: {
     showConnectionErrorMessage: _.debounce(function () {
       this.$message.error(`connection error: Please check IP address OR your internet connection`)
+    }, 1000),
+
+    showTransferErrorMessage: _.debounce(function () {
+      const { assetId, to, amount, error } = this.transferError
+
+      this.$message.error({
+        message: `Your transaction (asset=${assetId}, to=${to}, amount=${amount}) failed. Please check if the parameters are correct.`,
+        duration: 0,
+        showClose: true
+      })
     }, 1000)
   }
 }

--- a/src/components/Wallet.vue
+++ b/src/components/Wallet.vue
@@ -94,8 +94,8 @@ export default {
       })
         .then(() => {
           this.$message({
-            message: 'Transfer successful!',
-            type: 'success'
+            message: 'Transaction was submitted.',
+            type: 'info'
           })
           this.activeTabName = 'history'
         })

--- a/src/store/Account.js
+++ b/src/store/Account.js
@@ -30,7 +30,8 @@ function initialState () {
     rawUnsignedTransactions: [],
     rawTransactions: [],
     assets: [],
-    connectionError: null
+    connectionError: null,
+    transferError: null
   }
 }
 
@@ -166,10 +167,14 @@ const mutations = {
 
   [types.TRANSFER_ASSET_REQUEST] (state) {},
 
-  [types.TRANSFER_ASSET_SUCCESS] (state, { assetId, to, amount }) {},
+  [types.TRANSFER_ASSET_SUCCESS] (state) {},
 
   [types.TRANSFER_ASSET_FAILURE] (state, { assetId, to, amount, error }) {
     handleError(state, error)
+
+    if (!state.connectionError) {
+      state.transferError = { assetId, to, amount, error }
+    }
   }
 }
 
@@ -314,10 +319,9 @@ const actions = {
           .on('data', finished => {
             if (!finished) return
 
-            commit(types.TRANSFER_ASSET_SUCCESS, { assetId, to, amount })
+            commit(types.TRANSFER_ASSET_SUCCESS)
           })
           .on('error', error => {
-            // TODO: show the error on UI
             commit(types.TRANSFER_ASSET_FAILURE, { assetId, to, amount, error })
           })
       })

--- a/src/util/iroha-util.js
+++ b/src/util/iroha-util.js
@@ -513,7 +513,6 @@ function addAssetQuantity (assetId, amount) {
  * @param {String} assetId
  * @param {String} description
  * @param {String} amount
- * @returns {Stream} a stream which emits the tx is committed or still being processed
  */
 function transferAsset (srcAccountId, destAccountId, assetId, description, amount) {
   debug('starting transferAsset...')


### PR DESCRIPTION
closes #17 

# description
I made irohaUtil.transferAsset() return a stream which emits the flag that the tx is committed or still being processed:

```js
// before
irohaUtil.transferAsset('from@test', 'to@test', 'coolcoin#test', 'hi', '12.3')
    .then(() => {
        // after 5 seconds sleep...
        console.log('COMMITTED')
    })

// after
irohaUtil.transferAsset('from@test', 'to@test', 'coolcoin#test', 'hi', '12.3')
    .then(statusStream => {
        console.log('tx was submitted')

        statusStream.on('data', isFinished => {
            if (isFinished) console.log('COMMITTED')
        })
    })
```

### why?
5s sleep, which was the previous implementation, was too long if the tx was committed immediately, was too short if the tx was not committed even after 5s; it was unstable. Besides, it was not user-friendly to lock the screen for a long while after an asset transfer.

Thanks to Iroha's supporting status streaming, we can now obtain tx's statuses via a stream and notify the result to the user asynchronously.

# how to check
1. `yarn serve:electron` to open the app.
2. Try to send an asset:
    * It will be successful with correct parameters.
    * Otherwise, it will show an error message at the top after a moment.
![electron](https://user-images.githubusercontent.com/1365915/44832187-c5cc2e80-ac64-11e8-8697-6da5388dfdbd.png)
